### PR TITLE
Create package for Miniconda builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,4 +20,5 @@ requirements:
 
 about:
   license: BSD-3-Clause
+  license_family: BSD
   summary: Powershell shortcut creator for Windows (using menuinst)


### PR DESCRIPTION
To build on Prefect.

The `win-64` node on Prefect has an issue with git at the moment. The build succeeds on Concourse: https://concourse.build.corp.continuum.io/teams/main/pipelines/pyim_powershell_shortcut

Only need to build on `win-64` (skip all other platforms).

Addresses: https://anaconda.atlassian.net/browse/DSNC-5387