### PR TITLE
Add DISTRIBUTION_NAME to prompt window name

### DIFF
--- a/recipe/menu-windows-ps.json
+++ b/recipe/menu-windows-ps.json
@@ -3,7 +3,7 @@
     "menu_items":
     [
         {
-            "name": "Anaconda Powershell Prompt",
+            "name": "Anaconda Powershell Prompt (${DISTRIBUTION_NAME})",
             "system": "%windir%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
             "scriptarguments": ["-ExecutionPolicy", "ByPass", "-NoExit", "-Command", "& '${ROOT_PREFIX}\\shell\\condabin\\conda-hook.ps1' ; conda activate '${PREFIX}' "],
             "icon": "${MENU_DIR}/Iconleak-Atrous-PSConsole.ico"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.0.1
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not win]
 
 app:


### PR DESCRIPTION
Restore old Miniconda behavior by adding the installation directory to prompt name.

Jira ticket: https://anaconda.atlassian.net/browse/PKG-1010