### PR TITLE
bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.0.1
 
 build:
-  number: 1
+  number: 2
   skip: True  # [not win]
 
 app:


### PR DESCRIPTION
Follow up of #3 
The build number needed to be incremented as there is already a build 1 published.